### PR TITLE
Add CRS309-1G-8S+IN Switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ In this section, gear will be split between devices which natively mount in a 10
   - [MikroTik CRS310-1G-5S-4S+IN 5x 1Gbps SFP 4x 10G SFP+ 1x 1Gbps Ethernet Switch](https://amzn.to/3VJKYBe)
   - [MikroTik CRS310-8G+2S+IN 8x 2.5Gbps 2x 10G SFP+ Router](https://amzn.to/3Dx4smb)
   - [MikroTik CRS112-8P-4S-IN 8x 1Gbps 4x 1Gbps SFP Router](https://amzn.to/4fivRpi)
+  - [MikroTik CRS309-1G-8S+IN 8x 10G SFP+ 1x 1Gbps Ethernet Switch](https://a.co/d/7vCCH4p)
   - [MikroTik CSS610-8P-2S+in 8x 1 Gbps PoE+ 2x SFP+ 10G Switch](https://amzn.to/3ZKAtP8)
   - [MikroTik CSS610-8G-2S+in 8x 1Gbps 2x SPF+ 10G Switch](https://amzn.to/3OYAjyV)
   - [YuanLey YS2083GS-P 8-port PoE+, 2-port 1 Gbps, 1-port SFP 120W Unmanaged switch](https://amzn.to/41Y3qKv)


### PR DESCRIPTION
Dimensions: 272 x 191 x 44 mm
Can be PoE+ powered