### PR TITLE
Remove reference to GeekPi SBC Tray supporting 3.5" HDDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ SBCs, or Single Board Computers, are ideal for mini racks, due to their low powe
 
 It can be difficult to adapt storage devices (especially full 3.5" hard drives!) into a mini rack, but there are always solutions—sometimes as simple as placing a 2-bay NAS on its side, or putting an entire 4-bay NAS on a shelf!
 
-  - [GeeekPi / DeskPi RackMate SBC Shelf](https://amzn.to/49H76C6) (can hard-mount two 2.5" or 3.5" HDDs side by side)
+  - [GeeekPi / DeskPi RackMate SBC Shelf](https://amzn.to/49H76C6) (can hard-mount two 2.5" HDDs side by side)
   - [10" Rack Hard Drive Mount](https://www.printables.com/model/142325-10-rack-harddrive-mount) (can hard-mount two 3.5" drives)
 
 ### <a name="shelves-and-blanking-panels"></a>Shelves and Blanking Panels


### PR DESCRIPTION
As per #122 you can't really properly install 3.5" HDDs on the GeekPi/DeskPi SBC Shelf. You can just about do it but it's really no better than a generic shelf.

This change just removes the text stating that 3.5" disks are supported.