### PR TITLE
added Pi Slice rack mount to sbc shelves section

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ SBCs, or Single Board Computers, are ideal for mini racks, due to their low powe
 | [Makerworld Arduino Uno Rack Mount](https://makerworld.com/en/models/1011789) | 2U | 3x Arduino Uno, 3D printable |
 | [Makerworld Raspberry Pi Zero Rack Mount](https://makerworld.com/en/models/982725) | 1U | 1x/3x Raspberry Pi Zero/Zero W/Zero 2 W, 3D printable |
 | [Racknex UM-SBC-30x Shelf](https://racknex.com/shop/raspberry-pi/?filter_rack=10-inch) | 1U, 2U | Raspberry Pi 2B/3B/3B+/4B/5 |
-| [Pi Slice Rack](https://github.com/Coole-Guus/pi-slice-rack) | 2U | 10x Raspberry Pi 3B/4B/5 without hats
+| [Pi Slice Rack](https://github.com/Coole-Guus/pi-slice-rack) | 2U | 10x Raspberry Pi 3B/4B/5 without hats |
 
 ### <a name="disk-shelves"></a>Disk Shelves
 


### PR DESCRIPTION
Added the Pi Slice Rack mount into the sbc shelves section.
<img width="1064" height="697" alt="fusion-img" src="https://github.com/user-attachments/assets/e6548562-4a5f-4c2d-b49b-c9705e31a346" />

solution for mounting 10 Pi into a 2U form factor.
